### PR TITLE
Code Review

### DIFF
--- a/imports/api/asteroids.js
+++ b/imports/api/asteroids.js
@@ -1,3 +1,23 @@
 import { Mongo } from 'meteor/mongo';
  
 export const AsteroidsDB = new Mongo.Collection('Asteroids');
+//Samuel Baquero no qutiaron el autopublish ni el insecure.
+//Deberían verse en esta página los publish de los datos del collection.
+if (Meteor.isServer) {
+  // This code only runs on the server
+  Meteor.publish('Asteroids', function asteroidsPublication() {
+    return AsteroidsDB.find();
+  });
+}
+//Y los métodos que modifican la base de datos.
+Meteor.methods({
+  'asteroids.insert'({asteroid}) {
+   //Algo que identifique que el usuario puede realizar la operación.
+    AsteroidsDB.insert({
+      asteroid
+    });
+  },
+  'asteroids.remove'(asteroidId) {
+    AsteroidsDB.remove(asteroidId);
+  },
+});


### PR DESCRIPTION
Debieron quitar insecure y autopublish.

Sin quitar autopublish todos los usuarios tienen acceso a todos los datos de cada collection, incluso los que deberían ser  secretos.
Sin quitar insecure las consultas desde react se pueden modificar desde el cliente, esto implica que cualquiera puede jugar con sus bases de datos, insertar y eliminar datos a placer.